### PR TITLE
Specify that fields related to the payer are not required

### DIFF
--- a/docs/administrator_role/resources.md
+++ b/docs/administrator_role/resources.md
@@ -570,7 +570,7 @@ Solo basta con seleccionar lo que se desee hacer y se obtiene como resultado:
 
 ***Campos por defecto***
 
-Los campos relacionados con el pagador como tipo de documento, documento, nombre, apellido y correo electrónico no son campos obligatorios, si no desea solicitar estos datos los puede eliminar del formulario.
+Los campos relacionados con el pagador como tipo de documento, documento, nombre, apellido y correo electrónico no son campos obligatorios, si no desea solicitar estos datos los puede eliminar del formulario, se debe tener en cuenta que si elimina alguno de estos campos tambien debe eliminar los demás campos relacionados con el pagador.
 
 ![microsites](../../images_folder/administrator/resources/Microsites/defFieldLayout.png)
 

--- a/docs/administrator_role/resources.md
+++ b/docs/administrator_role/resources.md
@@ -569,6 +569,9 @@ La opción de ***Diseño de los campos*** de los micrositios abiertos también c
 Solo basta con seleccionar lo que se desee hacer y se obtiene como resultado:
 
 ***Campos por defecto***
+
+Los campos relacionados con el pagador como tipo de documento, documento, nombre, apellido y correo electrónico no son campos obligatorios, si no desea solicitar estos datos los puede eliminar del formulario.
+
 ![microsites](../../images_folder/administrator/resources/Microsites/defFieldLayout.png)
 
 ***Campos mínimos***


### PR DESCRIPTION
Specify that the fields related to the payer such as document type and document are not required.